### PR TITLE
adapt bugzilla plugin for rhevm-qe usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status][travisimg]][travis]
+[![Build Status](https://travis-ci.org/rhevm-qe-automation/pytest_marker_bugzilla.svg?branch=master)](https://travis-ci.org/rhevm-qe-automation/pytest_marker_bugzilla)
 
 # Intro
 [PyTest][pytest] plugin for bugzilla integration. This plugin currently
@@ -58,3 +58,4 @@ Please also try to cover new features by writing new tests.
 [githubissues]: https://github.com/eanxgeek/pytest_marker_bugzilla/issues
 [travisimg]: https://travis-ci.org/rhevm-qe-automation/pytest_marker_bugzilla.svg?branch=master
 [travis]: https://travis-ci.org/rhevm-qe-automation/pytest_marker_bugzilla
+

--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ Please also try to cover new features by writing new tests.
 
 [pytest]: http://pytest.org/latest/
 [githubissues]: https://github.com/eanxgeek/pytest_marker_bugzilla/issues
-[travisimg]: https://travis-ci.org/rhevm-qe-automation/pytest-marker-bugzilla.svg?branch=master
-[travis]: https://travis-ci.org/rhevm-qe-automation/pytest-marker-bugzilla
+[travisimg]: https://travis-ci.org/rhevm-qe-automation/pytest_marker_bugzilla.svg?branch=master
+[travis]: https://travis-ci.org/rhevm-qe-automation/pytest_marker_bugzilla

--- a/results.txt
+++ b/results.txt
@@ -1,0 +1,29 @@
+s tests/test_bugzilla.py::TestNothing::()::test_new_bz
+ Skipped: Bug summary: ONE Status: NEW URL: https://bugzilla.redhat.com/show_bug.cgi?id=1
+. tests/test_bugzilla.py::TestNothing::()::test_closed_bz
+F tests/test_bugzilla.py::TestNothing::()::test_closed_bz_with_failure
+ self = <tests.test_bugzilla.TestNothing object at 0x7ff246593dd0>
+ 
+     @pytest.mark.bugzilla({'2': {}})
+     def test_closed_bz_with_failure(self):
+ >       assert(os.path.exists('/etcccc'))
+ E       assert <function exists at 0x7ff254712938>('/etcccc')
+ E        +  where <function exists at 0x7ff254712938> = <module 'posixpath' from '/usr/lib64/python2.7/posixpath.pyc'>.exists
+ E        +    where <module 'posixpath' from '/usr/lib64/python2.7/posixpath.pyc'> = os.path
+ 
+ tests/test_bugzilla.py:22: AssertionError
+. tests/test_bugzilla.py::TestNothing::()::test_without_bugzilla
+F tests/test_bugzilla.py::TestNothing::()::test_fail_without_bugzilla
+ self = <tests.test_bugzilla.TestNothing object at 0x7ff2465a8550>
+ 
+     def test_fail_without_bugzilla(self):
+ >       assert(os.path.exists('/etc123'))
+ E       assert <function exists at 0x7ff254712938>('/etc123')
+ E        +  where <function exists at 0x7ff254712938> = <module 'posixpath' from '/usr/lib64/python2.7/posixpath.pyc'>.exists
+ E        +    where <module 'posixpath' from '/usr/lib64/python2.7/posixpath.pyc'> = os.path
+ 
+ tests/test_bugzilla.py:28: AssertionError
+. tests/test_bugzilla.py::TestNothing::()::test_verified_bz
+. tests/test_bugzilla.py::TestNothing::()::test_closed_bz_2
+s tests/test_bugzilla.py::TestNothing::()::test_modified_bz
+ Skipped: Bug summary: FIVE Status: MODIFIED URL: https://bugzilla.redhat.com/show_bug.cgi?id=5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,18 +4,49 @@ import pytest
 
 FAKE_BUGS = {
     "1": {
-        "id": 1,
+        "id": '1',
         "version": None,
         "fixed_in": None,
         "status": 'NEW',
         "target_release": None,
+        "resolution": 'foo',
+        "summary": 'ONE',
     },
     "2": {
-        "id": 2,
+        "id": '2',
+        "version": None,
+        "fixed_in": None,
+        "status": 'ON_QA',
+        "target_release": None,
+        "resolution": 'foo',
+        "summary": 'TWO',
+    },
+    "3": {
+        "id": '3',
+        "version": None,
+        "fixed_in": None,
+        "status": 'VERIFIED',
+        "target_release": None,
+        "resolution": 'foo',
+        "summary": 'THREE',
+    },
+    "4": {
+        "id": '4',
         "version": None,
         "fixed_in": None,
         "status": 'CLOSED',
         "target_release": None,
+        "resolution": 'DUPLICATE',
+        "summary": 'FOUR',
+    },
+    "5": {
+        "id": '5',
+        "version": None,
+        "fixed_in": None,
+        "status": 'MODIFIED',
+        "target_release": None,
+        "resolution": 'foo',
+        "summary": 'FIVE',
     },
 }
 

--- a/tests/test_bugzilla.py.in
+++ b/tests/test_bugzilla.py.in
@@ -9,15 +9,15 @@ import pytest
 @pytest.mark.nondestructive
 class TestNothing(object):
 
-    @pytest.mark.bugzilla('1')
+    @pytest.mark.bugzilla({'1': {}})
     def test_new_bz(self):
         assert(os.path.exists('/etcccc'))
 
-    @pytest.mark.bugzilla('2')
+    @pytest.mark.bugzilla({'2': {}})
     def test_closed_bz(self):
         assert(os.path.exists('/etc'))
 
-    @pytest.mark.bugzilla('2')
+    @pytest.mark.bugzilla({'2': {}})
     def test_closed_bz_with_failure(self):
         assert(os.path.exists('/etcccc'))
 
@@ -26,3 +26,15 @@ class TestNothing(object):
 
     def test_fail_without_bugzilla(self):
         assert(os.path.exists('/etc123'))
+
+    @pytest.mark.bugzilla({'3': {}})
+    def test_verified_bz(self):
+        assert(os.path.exists('/etc'))
+
+    @pytest.mark.bugzilla({'4': {}})
+    def test_closed_bz_2(self):
+        assert(os.path.exists('/etc'))
+
+    @pytest.mark.bugzilla({'5': {}})
+    def test_modified_bz(self):
+        assert(os.path.exists('/etc'))

--- a/tests/test_nothing.py
+++ b/tests/test_nothing.py
@@ -41,6 +41,7 @@ class TestNothing(object):
                             "[DEFAULT]",
                             "bugzilla_url = "
                             "https://bugzilla.redhat.com/xmlrpc.cgi",
+
                         ]
                     )
                 )

--- a/tests/test_nothing.py
+++ b/tests/test_nothing.py
@@ -33,18 +33,8 @@ class TestNothing(object):
     def setup_class(cls):
         # Create config file
         config = "bugzilla.cfg"
-        if not os.path.exists(config):
-            with open(config, "w") as fh:
-                fh.write(
-                    "\n".join(
-                        [
-                            "[DEFAULT]",
-                            "bugzilla_url = "
-                            "https://bugzilla.redhat.com/xmlrpc.cgi",
 
-                        ]
-                    )
-                )
+        assert os.path.exists(config), "please create bugzilla.cfg"
 
         # Create test
         with open(cls.test_file + ".in") as fhs:

--- a/tests/test_nothing.py
+++ b/tests/test_nothing.py
@@ -103,3 +103,21 @@ class TestNothing(object):
         No decorator, failing test-case, it should fail.
         """
         self._assert_result('F', 'test_fail_without_bugzilla')
+
+    def test_verified_bz(self):
+        """
+        verified bug, passing test-case, it should pass.
+        """
+        self._assert_result('.', 'test_verified_bz')
+
+    def test_closed_bz_2(self):
+        """
+        closed bug, passing test-case, it should pass.
+        """
+        self._assert_result('.', 'test_closed_bz_2')
+
+    def test_modified_bz(self):
+        """
+        modified bug, test-case should skip.
+        """
+        self._assert_result('s', 'test_modified_bz')


### PR DESCRIPTION
1. Now we take into consideration engine and storage
2. Bugzilla marker looks like
   - `@bz({'bz-id': {'engine': [], 'storage': []}})` bz affects all engines and all storages
   - `@bz({'bz-id': {'engine': ['cli'], 'storage': []}})` bz afects CLI and all storages
   - `@bz({'bz-id': {'engine': ['cli', 'rest'], 'storage': ['iscsi']}})` bz affects rest and cli and iscsi
