### PR TITLE
Storage skip: change in storage skipping

### DIFF
--- a/pytest_marker_bugzilla.py
+++ b/pytest_marker_bugzilla.py
@@ -162,7 +162,13 @@ class BugzillaHooks(object):
         if not storages:
             return True
 
-        return item.parent.obj.storage in storages
+        if "storage" in item.fixturenames:
+            for storage in storages:
+                if storage in item._genid:
+                    return True
+            return False
+        else:
+            return item.parent.obj.storage in storages
 
     def _should_skip_due_to_ppc(self, item, is_ppc):
         return is_ppc is None or is_ppc is True


### PR DESCRIPTION
In testing ovirt 4.2 we change approach how to generate tests for particular
storage types. Now we are using parametrize of fixture called storage, but
problem is that this fixture is parametrized after pytest_runtest_setup.
Pytest put all parametrized values of test to item._genid which is e.g.
string "nfs-foo-bar" in case you parametrized that test with nfs, foo,
bar.

This change is backward compatibility because I it's just looking for used
fixture storage and if it's there it's using new approach otherwise using old
approach.

Change-Id: Ie0bb214cad2251b5a236446307df3cc145ad4bd4