### PR TITLE
tests: Removed py26 matrix added 3.5 & 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "3.4"
+    - "3.5"
+    - "3.6"
 install:
     - pip install tox tox-travis
 script:

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,10 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Utilities',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     cmdclass={'test': PyTest,},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py26,py27,py34,pep8
+envlist = py27,py34,py35,py36,pep8
 [tox:travis]
-2.6 = py26
 2.7 = py27, pep8
 3.4 = py34, pep8
+3.5 = py35, pep8
+3.6 = py36, pep8
 [testenv]
 deps=
   pytest


### PR DESCRIPTION
py26 is already dead and it is failing our travis