### PR TITLE
Remove python 2.6 cause it's depricated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "3.4"
 install:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Utilities',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
-envlist = py26,py27,py34,pep8
+envlist = py27,py34,pep8
 [tox:travis]
-2.6 = py26
 2.7 = py27, pep8
 3.4 = py34, pep8
 [testenv]


### PR DESCRIPTION
Python 2.6 is not supported by Travis CI.