### PR TITLE
Fix for pytest (python3).

### DIFF
--- a/pytest_marker_bugzilla.py
+++ b/pytest_marker_bugzilla.py
@@ -205,7 +205,7 @@ class BugzillaHooks(object):
             return
 
         bugs_in_cache = item.funcargs["bugs_in_cache"]
-        bugzilla_marker_related_to_case = item.get_marker('bugzilla')
+        bugzilla_marker_related_to_case = item.get_closest_marker(name='bugzilla')
         xfail = kwargify(
             bugzilla_marker_related_to_case.kwargs.get(
                 "xfail_when", lambda: False
@@ -333,22 +333,20 @@ class BugzillaHooks(object):
         if reporter:
             reporter.write("Checking for bugzilla-related tests\n", bold=True)
         cache = {}
-        for i, item in enumerate(
-            filter(lambda i: i.get_marker("bugzilla") is not None, items)
-        ):
-            marker = item.get_marker('bugzilla')
-            bugs = marker.args[0]
-            bugs_ids = bugs.keys()
+        for item in items:
+            for marker in item.iter_markers(name='bugzilla'):
+                bugs = marker.args[0]
+                bugs_ids = bugs.keys()
 
-            for bz_id in bugs_ids:
-                if bz_id not in cache:
-                    if reporter:
-                        reporter.write(".")
-                    cache[bz_id] = BugzillaBugs(
-                        self.bugzilla, self.loose, bz_id
-                    )
+                for bz_id in bugs_ids:
+                    if bz_id not in cache:
+                        if reporter:
+                            reporter.write(".")
+                        cache[bz_id] = BugzillaBugs(
+                            self.bugzilla, self.loose, bz_id
+                        )
 
-            item.funcargs["bugs_in_cache"] = cache
+                item.funcargs["bugs_in_cache"] = cache
 
         if reporter:
             reporter.write(

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,18 @@
 [tox]
-envlist = py27,py37,pep8
+envlist = py{27,37}-pytest{361,431}
+
 [tox:travis]
-2.7 = py27, pep8
-3.7 = py37, pep8
+2.7 = py27-pytest361, py27-pytest431, pep8
+3.7 = py37-pytest361, py37-pytest431, pep8
+
 [testenv]
-deps=
-  pytest
-  pytest-xdist
-  pytest-cov
+deps =
+    pytest361: pytest==3.6.1
+    pytest431: pytest==4.3.1
+    pytest-xdist
+    pytest-cov
 commands=
-  py.test \
+  pytest \
       --basetemp={envtmpdir} \
       -p pytester \
       --cov pytest_marker_bugzilla \

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,10 @@ commands=
       --cov-report term \
       --cov-report html \
       {posargs}
+
+[flake8]
+max-line-length = 120
+
 [testenv:pep8]
 deps=flake8
 commands=flake8 pytest_marker_bugzilla.py tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py27,py34,pep8
+envlist = py27,py37,pep8
 [tox:travis]
 2.7 = py27, pep8
-3.4 = py34, pep8
+3.7 = py37, pep8
 [testenv]
 deps=
   pytest


### PR DESCRIPTION
get_marker() is gone on pytest (py3).