### PR TITLE
Add api-key support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-bugzilla
+pytest == 6.2.5
+six


### PR DESCRIPTION
This change adds the support for the --bugzilla-api-key CLI flag
which will replace UN/PW auth to the Bugzilla instance.

[JIRA ticket](https://issues.redhat.com/browse/RHEVM-6508)